### PR TITLE
Changed Dispose semantics for InfoBufferArray

### DIFF
--- a/OpenCL.Net.Tests/APITests.cs
+++ b/OpenCL.Net.Tests/APITests.cs
@@ -142,6 +142,26 @@ namespace OpenCL.Net.Tests
             using (Context context = Cl.CreateContext(null, 1, new[] { device }, null, IntPtr.Zero, out error))
                 refCount = Cl.GetContextInfo(context, ContextInfo.ReferenceCount, out error).CastTo<uint>();
         }
+
+		[Test]
+		public void InfoBufferArrayFromByteArray()
+		{
+			var byteArray = new byte[] { 1, 2, 3, 4, 5 };
+			using (var infoBuffer = new InfoBuffer(byteArray))
+			{
+				Assert.AreEqual(byteArray.Length, infoBuffer.Size);
+				using (var infoBufferArray = new InfoBufferArray(infoBuffer))
+				{
+					Assert.AreEqual(1, infoBufferArray.Length);
+
+					var backToByteArray = infoBufferArray[0].CastToArray<byte>(byteArray.Length);
+					for (int i = 0; i < byteArray.Length; i++)
+					{
+						Assert.AreEqual(byteArray[i], backToByteArray[i]);
+					}
+				}
+			}
+		}
     }
 
     [TestFixture]

--- a/OpenCL.Net/Cl.Types.cs
+++ b/OpenCL.Net/Cl.Types.cs
@@ -869,11 +869,7 @@ namespace OpenCL.Net
 
         public void Dispose()
         {
-            for (int i = 0; i < _buffers.Length; i++)
-                new InfoBuffer
-                {
-                    Address = _buffers[i]
-                }.Dispose();
+			//Do not free InfoBuffers here--they were allocated outside of our scope, allow the caller to free them as well
         }
     }
 

--- a/OpenCL.Net/Cl.Types.cs
+++ b/OpenCL.Net/Cl.Types.cs
@@ -876,8 +876,8 @@ namespace OpenCL.Net
     [StructLayout(LayoutKind.Sequential)]
     public struct InfoBuffer : IDisposable
     {
-        [DllImport("msvcrt.dll", EntryPoint = "memcpy")]
-        private static extern void CopyMemory(IntPtr pDest, IntPtr pSrc, int length);
+		[DllImport("msvcrt.dll", EntryPoint = "memcpy", CallingConvention = CallingConvention.Cdecl, SetLastError = false)]
+		private static extern void CopyMemory(IntPtr pDest, IntPtr pSrc, int length);
 
         private static readonly InfoBuffer _empty = new InfoBuffer
         {

--- a/OpenCL.Net/FodyWeavers.xml
+++ b/OpenCL.Net/FodyWeavers.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Weavers>
   <ExtraConstraints />
 </Weavers>

--- a/OpenCL.Net/OpenCL.Net.csproj
+++ b/OpenCL.Net/OpenCL.Net.csproj
@@ -17,7 +17,8 @@
     </TargetFrameworkProfile>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
-    <FodyPath>..\packages\Fody.1.17.4.0</FodyPath>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -55,9 +56,9 @@
     <CodeAnalysisFailOnMissingRules>false</CodeAnalysisFailOnMissingRules>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="ExtraConstraints">
-      <HintPath>..\packages\ExtraConstraints.Fody.1.9.0.0\Lib\portable-net4+sl4+wp7+win8+MonoAndroid16+MonoTouch40\ExtraConstraints.dll</HintPath>
-      <Private>False</Private>
+    <Reference Include="ExtraConstraints, Version=1.10.7.0, Culture=neutral, PublicKeyToken=8b9afd7f380a7d64, processorArchitecture=MSIL">
+      <HintPath>..\packages\ExtraConstraints.Fody.1.10.7\lib\portable-net4+sl5+wp8+win8+wpa81+MonoAndroid16+MonoTouch40\ExtraConstraints.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.DebuggerVisualizers, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="System" />
@@ -94,7 +95,6 @@
       <Generator>TextTemplatingFileGenerator</Generator>
       <LastGenOutput>Cl.VectorTypes.cs</LastGenOutput>
     </None>
-    <None Include="Fody.targets" />
     <None Include="net40\OpenCL.Net.targets">
       <SubType>Designer</SubType>
     </None>
@@ -136,5 +136,11 @@ goto end
 :end</PostBuildEvent>
   </PropertyGroup>
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
-  <Import Project="Fody.targets" />
+  <Import Project="..\packages\Fody.1.29.3\build\portable-net+sl+win+wpa+wp\Fody.targets" Condition="Exists('..\packages\Fody.1.29.3\build\portable-net+sl+win+wpa+wp\Fody.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\Fody.1.29.3\build\portable-net+sl+win+wpa+wp\Fody.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Fody.1.29.3\build\portable-net+sl+win+wpa+wp\Fody.targets'))" />
+  </Target>
 </Project>

--- a/OpenCL.Net/packages.config
+++ b/OpenCL.Net/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="ExtraConstraints.Fody" version="1.9.0.0" targetFramework="net40" developmentDependency="true"/>
-  <package id="Fody" version="1.17.4.0" targetFramework="net40" developmentDependency="true"/>
+  <package id="ExtraConstraints.Fody" version="1.10.7" targetFramework="net4" developmentDependency="true" />
+  <package id="Fody" version="1.29.3" targetFramework="net4" developmentDependency="true" />
 </packages>


### PR DESCRIPTION
See included test for an unmanaged double-free error with existing code.  InfoBufferArray can only be constructed with existing InfoBuffers, so the lifetime of the contained InfoBuffers should be managed outside of the InfoBufferArray, i.e. their unmanaged memory shouldn't be freed upon InfoBufferArray disposal.

This pull request includes changes previously requested to allow a VS2015 build.
